### PR TITLE
Added support to iOSSimARM64, MacOS and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,14 @@
 Thumbs.db
 #ignore Delphi build directories
 Android/
-iOSDevice/
-iOSDevice32/
+Android64/
 iOSDevice64/
 iOSSimulator/
+iOSSimARM64/
+Linux64/
 OSX32/
+OSX64/
+OSXARM64/
 Win32/
 Win64/
 #ignore Delphi build files

--- a/Models/Model.Common.pas
+++ b/Models/Model.Common.pas
@@ -6,7 +6,7 @@ interface
 
 type
   { Supported target platforms }
-  TTargetPlatform = (Unknown, iOS, Android);
+  TTargetPlatform = (Unknown, iOS, Android, MacOS, Linux);
 
 implementation
 

--- a/Models/Model.DelphiProjectFile.pas
+++ b/Models/Model.DelphiProjectFile.pas
@@ -147,7 +147,6 @@ uses
   Supported platforms:
   * iOSDevice64
   * iOSSimARM64
-  * iOSSimulator
   * Android
   * Android64
   * OSX64
@@ -169,11 +168,11 @@ procedure TDelphiProjectFile.Add(const ALocalName, ARemoteDir: String;
   const APlatform: TTargetPlatform; const AForConfigurations: TArray<String>);
 const
   PLATFORM_NAMES: array [TTargetPlatform, 0..2] of String =
-   (('', '', ''),                                   // Unknown
-    ('iOSDevice64', 'iOSSimARM64', 'iOSSimulator'), // iOS
-    ('Android', 'Android64', ''),                   // Android
-    ('OSX64', 'OSXARM64', ''),                      // MacOS
-    ('Linux64', '', ''));                           // Linux
+   (('', '', ''),                       // Unknown
+    ('iOSDevice64', 'iOSSimARM64', ''), // iOS
+    ('Android', 'Android64', ''),       // Android
+    ('OSX64', 'OSXARM64', ''),          // MacOS
+    ('Linux64', '', ''));               // Linux
 begin
   if (FDeploymentElement = nil) then
     Exit;
@@ -349,7 +348,7 @@ begin
   var Name := AElement.AttributeByName('Name').Value;
   if (Name = 'Android') then
     Platf := TTargetPlatform.Android
-  else if (Name = 'iOSDevice64') or (Name = 'iOSSimARM64') or (Name = 'iOSSimulator') then
+  else if (Name = 'iOSDevice64') or (Name = 'iOSSimARM64') then
     Platf := TTargetPlatform.iOS
   else if (Name = 'OSX64') or (Name = 'OSXARM64') then
     Platf := TTargetPlatform.MacOS

--- a/Models/Model.DelphiProjectFile.pas
+++ b/Models/Model.DelphiProjectFile.pas
@@ -146,6 +146,7 @@ uses
 
   Supported platforms:
   * iOSDevice64
+  * iOSSimARM64
   * iOSSimulator
   * Android
   * Android64
@@ -168,11 +169,11 @@ procedure TDelphiProjectFile.Add(const ALocalName, ARemoteDir: String;
   const APlatform: TTargetPlatform; const AForConfigurations: TArray<String>);
 const
   PLATFORM_NAMES: array [TTargetPlatform, 0..2] of String =
-   (('', '', ''),                        // Unknown
-    ('iOSDevice64', 'iOSSimulator', ''), // iOS
-    ('Android', 'Android64', ''),        // Android
-    ('OSX64', 'OSXARM64', ''),           // MacOS
-    ('Linux64', '', ''));                // Linux
+   (('', '', ''),                                   // Unknown
+    ('iOSDevice64', 'iOSSimARM64', 'iOSSimulator'), // iOS
+    ('Android', 'Android64', ''),                   // Android
+    ('OSX64', 'OSXARM64', ''),                      // MacOS
+    ('Linux64', '', ''));                           // Linux
 begin
   if (FDeploymentElement = nil) then
     Exit;
@@ -348,7 +349,7 @@ begin
   var Name := AElement.AttributeByName('Name').Value;
   if (Name = 'Android') then
     Platf := TTargetPlatform.Android
-  else if (Name = 'iOSDevice64') or (Name = 'iOSSimulator') then
+  else if (Name = 'iOSDevice64') or (Name = 'iOSSimARM64') or (Name = 'iOSSimulator') then
     Platf := TTargetPlatform.iOS
   else if (Name = 'OSX64') or (Name = 'OSXARM64') then
     Platf := TTargetPlatform.MacOS

--- a/Models/Model.DelphiProjectFile.pas
+++ b/Models/Model.DelphiProjectFile.pas
@@ -88,7 +88,7 @@ type
         ALocalName: the name (including directory) on the local file system of
           the file to be deployed.
         ARemoteDirectory: the target directory on the device to deploy to.
-        APlatform: the target platform for the file (iOS or Android)
+        APlatform: the target platform for the file (iOS, Android, MacOS or Linux)
         AForConfigurations: the build configurations to add the file to.
           Can be nil (empty) to apply to all configurations. }
     procedure Add(const ALocalName, ARemoteDir: String;
@@ -148,7 +148,10 @@ uses
   * iOSDevice64
   * iOSSimulator
   * Android
-  * Android64 }
+  * Android64
+  * OSX64
+  * OSXARM64
+  * Linux64 }
 
 { TDelphiProjectFile.TDeployFile }
 
@@ -167,7 +170,9 @@ const
   PLATFORM_NAMES: array [TTargetPlatform, 0..2] of String =
    (('', '', ''),                        // Unknown
     ('iOSDevice64', 'iOSSimulator', ''), // iOS
-    ('Android', 'Android64', ''));       // Android
+    ('Android', 'Android64', ''),        // Android
+    ('OSX64', 'OSXARM64', ''),           // MacOS
+    ('Linux64', '', ''));                // Linux
 begin
   if (FDeploymentElement = nil) then
     Exit;
@@ -345,6 +350,10 @@ begin
     Platf := TTargetPlatform.Android
   else if (Name = 'iOSDevice64') or (Name = 'iOSSimulator') then
     Platf := TTargetPlatform.iOS
+  else if (Name = 'OSX64') or (Name = 'OSXARM64') then
+    Platf := TTargetPlatform.MacOS
+  else if Name = 'Linux64' then
+    Platf := TTargetPlatform.Linux
   else
     Exit;
 

--- a/Models/Model.GrijjyDeployFile.pas
+++ b/Models/Model.GrijjyDeployFile.pas
@@ -52,6 +52,12 @@ type
 
     { All deployment entries for the Android platform }
     Android: TDeployEntries;
+
+    { All deployment entries for the MacOS platform }
+    MacOS: TDeployEntries;
+
+    { All deployment entries for the Linux platform }
+    Linux: TDeployEntries;
   public
     procedure Initialize;
   end;
@@ -94,7 +100,7 @@ type
     { Adds a file or directory to be deployed.
 
       Parameters:
-        APlatform: the target platform (iOS or Android)
+        APlatform: the target platform (iOS, Android, MacOS or Linux)
         ALocalName: the name of the file or directory to deploy (on the local
           file system)
         ARemoteDir: the target directory on the device to deploy to.
@@ -113,7 +119,7 @@ type
       Parameters:
         ALocalName: the name of the file or directory to remove (on the local
           file system)
-        APlatform: the target platform (iOS or Android)
+        APlatform: the target platform (iOS, Android, MacOS or Linux)
 
       Returns:
         True if there was an entry for ALocalName, of False if not. }
@@ -156,6 +162,8 @@ begin
   Configurations := nil;
   iOS := nil;
   Android := nil;
+  MacOS := nil;
+  Linux := nil;
 end;
 
 { TDeployFile }
@@ -228,6 +236,8 @@ begin
   FConfigurations := Data.Configurations;
   AddEntries(TTargetPlatform.iOS, Data.iOS);
   AddEntries(TTargetPlatform.Android, Data.Android);
+  AddEntries(TTargetPlatform.MacOS, Data.MacOS);
+  AddEntries(TTargetPlatform.Linux, Data.Linux);
 end;
 
 function TDeployFile.Remove(const ALocalName: String;
@@ -251,6 +261,8 @@ begin
   Data.Configurations := FConfigurations;
   Data.iOS := FDeployEntries[TTargetPlatform.iOS].Values.ToArray;
   Data.Android := FDeployEntries[TTargetPlatform.Android].Values.ToArray;
+  Data.MacOS := FDeployEntries[TTargetPlatform.MacOS].Values.ToArray;
+  Data.Linux := FDeployEntries[TTargetPlatform.Linux].Values.ToArray;
 
   var Json: String;
   TgoBsonSerializer.Serialize(Data, TgoJsonWriterSettings.Pretty, Json);

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Grijjy Deployment Manager
-The Grijjy Deployment Manager (DeployMan) is a tool to simplify the deployment of files and folders for iOS and Android apps written in Delphi. It is especially useful if you need to deploy a lot of files, such as 3rd party SDKs.
+The Grijjy Deployment Manager (DeployMan) is a tool to simplify the deployment of files and folders for Android, iOS, MacOS and Linux apps written in Delphi. It is especially useful if you need to deploy a lot of files, such as 3rd party SDKs.
 
 ## Usage
 
@@ -33,6 +33,6 @@ Contributions are welcome! If you want to contribute, you can either create a pu
 
 ## License
 
-The Grijjy Deployment Manager is licensed under the Simplified BSD License. 
+The Grijjy Deployment Manager is licensed under the Simplified BSD License.
 
 See License.txt for details.

--- a/Views/View.Main.dfm
+++ b/Views/View.Main.dfm
@@ -27,7 +27,9 @@ object ViewMain: TViewMain
     TabOrder = 0
     Tabs.Strings = (
       'iOS'
-      'Android')
+      'Android'
+      'MacOS'
+      'Linux')
     TabIndex = 0
     OnChange = TabControlChange
     object ListViewEntries: TListView

--- a/Views/View.Main.pas
+++ b/Views/View.Main.pas
@@ -500,13 +500,22 @@ begin
   try
     ComboBoxTargetDir.Items.Clear;
     ComboBoxTargetDir.Items.Add('.\');
-    if (APlatform = TTargetPlatform.iOS) then
-      ComboBoxTargetDir.Items.Add('StartUp\Documents\')
+    case APlatform of
+      TTargetPlatform.iOS: ComboBoxTargetDir.Items.Add('StartUp\Documents\');
+      TTargetPlatform.Android:
+        begin
+          ComboBoxTargetDir.Items.Add('assets\internal');
+          ComboBoxTargetDir.Items.Add('assets\external');
+          ComboBoxTargetDir.Items.Add('res\values\');
+        end;
+      TTargetPlatform.MacOS:
+        begin
+          ComboBoxTargetDir.Items.Add('Contents\MacOS\');
+          ComboBoxTargetDir.Items.Add('Contents\Resources\');
+          ComboBoxTargetDir.Items.Add('Contents\Resources\StartUp\');
+        end;
+      TTargetPlatform.Linux: ComboBoxTargetDir.Items.Add('StartUp\');
     else
-    begin
-      ComboBoxTargetDir.Items.Add('assets\internal');
-      ComboBoxTargetDir.Items.Add('assets\external');
-      ComboBoxTargetDir.Items.Add('res\values\');
     end;
   finally
     ComboBoxTargetDir.Items.EndUpdate;
@@ -540,10 +549,13 @@ end;
 
 procedure TViewMain.TabControlChange(Sender: TObject);
 begin
-  if (TabControl.TabIndex = 0) then
-    ShowSettings(TTargetPlatform.iOS)
+  case TabControl.TabIndex of
+    0: ShowSettings(TTargetPlatform.iOS);
+    1: ShowSettings(TTargetPlatform.Android);
+    2: ShowSettings(TTargetPlatform.MacOS);
+    3: ShowSettings(TTargetPlatform.Linux);
   else
-    ShowSettings(TTargetPlatform.Android);
+  end;
 end;
 
 procedure TViewMain.UpdateCaption;

--- a/Views/View.Main.pas
+++ b/Views/View.Main.pas
@@ -501,7 +501,12 @@ begin
     ComboBoxTargetDir.Items.Clear;
     ComboBoxTargetDir.Items.Add('.\');
     case APlatform of
-      TTargetPlatform.iOS: ComboBoxTargetDir.Items.Add('StartUp\Documents\');
+      TTargetPlatform.iOS:
+        begin
+          ComboBoxTargetDir.Items.Add('StartUp\Documents\');
+          ComboBoxTargetDir.Items.Add('StartUp\Library\');
+          ComboBoxTargetDir.Items.Add('StartUp\Library\Caches\');
+        end;
       TTargetPlatform.Android:
         begin
           ComboBoxTargetDir.Items.Add('assets\internal');


### PR DESCRIPTION
Added support to OSX64, OSXARM64 and Linux64. The changes have been tested and we are already using them in the Skia4Delphi project. See the [grdeploy file of our demo](https://github.com/skia4delphi/skia4delphi/blob/main/Samples/Demo/FMX/Projects/RAD%20Studio%2011.0%20Alexandria/Skia4Delphi.grdeploy).

In Mac there are three remote paths important in deployment:
 - `Contents\MacOS\` is the binary folder, important to deploy dylib for example. If you add the file "a.dylib" in mac deployment with this remote path, you can load it using path `a.dylib`.
 - `Contents\Resources\` is the internal resources folder of the application. This is the most common directory of resources. If you add the file "a.png" in mac deployment with this remote path, you can load it using path `'../Resources/a.png'`
 - `Contents\Resources\StartUp\` is a subdir of the internal resources folder of the application, created by embarcadero to be copied to the home path of the Mac in application initialization. If you add the file "a.png" in mac deployment with this remote path, you can load it using path `'../Resources/StartUp/a.png'`, but also, you can load it using  `TPath.Combine(TPath.GetHomePath, 'a.png')` that will be a copy of the file in home path: `/Users/<username>/a.png`

In Linux, the important remote path is the `.\`. The files can be access using, for example, the code `ExtractFilePath(ParamStr(0))`.

![image](https://user-images.githubusercontent.com/11139086/155399735-3fb1d1ca-8590-4f78-869b-1a9707d21e93.png)